### PR TITLE
Improve distributed load display

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ El programa usa **variables `tk.DoubleVar` y `tk.StringVar`** para guardar valor
 * **Reacciones en los apoyos**, considerando todas las cargas y el par torsor.
 * **Centro de masa** de todas las cargas.
 * **Diagramas de cortante, momento flector y torsión**.
-* **Par torsor en cualquier punto** y fuerza equivalente de cargas distribuidas.
+* **Par torsor (torque) en cualquier punto** y fuerza equivalente de cargas distribuidas.
 * **Centro de masa en 3D** y cálculo de fuerza a partir de un par torsor.
 * También calcula propiedades como el **área total**, **centro de gravedad de la sección transversal**, y **momento de inercia**.
 
@@ -54,6 +54,7 @@ El programa usa **variables `tk.DoubleVar` y `tk.StringVar`** para guardar valor
 El simulador puede dibujar:
 
 * La **viga con sus cargas** y sus **reacciones**.
+* Las **cargas distribuidas** se simplifican y solo se dibuja su **fuerza equivalente** en el diagrama de cuerpo libre.
 * **Diagramas de fuerza cortante y momento flector**.
 * **Vista 3D rotativa** de la viga con cargas y apoyos.
 * **Vista de la sección transversal** y el centro de gravedad de figuras combinadas.
@@ -82,7 +83,7 @@ Además se añadió un **modo oscuro** seleccionable desde los controles princip
 
 ### 8. Par torsor en un punto
 
-Esta función permite obtener el momento torsor interno en una posición específica de la viga.
+Esta función permite obtener el momento torsor (torque interno) en una posición específica de la viga.
 Solo escribe la coordenada en metros en el cuadro **Par en Punto** y presiona el botón del mismo nombre.
 El valor se mostrará en el registro y en los diagramas.
 

--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -699,15 +699,43 @@ class SimuladorVigaMejorado:
             ax.arrow(pos, h+0.5, 0, -0.4, head_width=L*0.015, head_length=0.05, fc='#d62728', ec='#d62728', width=0.002, zorder=15)
             ax.text(pos, h+0.6, f'{mag}N', ha='center', va='bottom', fontsize=10, color='#d62728', fontweight='bold')
 
-        # Dibujar cargas distribuidas
+        # Dibujar cargas distribuidas como fuerza equivalente
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 50)
-            y_dist = h_inicial + (h_final - h_inicial) * x_dist / L + 0.4
-            ax.plot(x_dist, y_dist, '#ff7f0e', linewidth=2, zorder=15)
-            for x_pos in x_dist[::5]:
-                h = h_inicial + (h_final - h_inicial) * x_pos / L
-                ax.arrow(x_pos, h+0.4, 0, -0.3, head_width=L*0.008, head_length=0.02, fc='#ff7f0e', ec='#ff7f0e', width=0.001, zorder=15)
-            ax.text((inicio+fin)/2, h+0.5, f'{mag}N/m', ha='center', va='bottom', fontsize=10, color='#ff7f0e', fontweight='bold')
+            h_mid = h_inicial + (h_final - h_inicial) * ((inicio + fin) / 2) / L
+            ax.text(
+                (inicio + fin) / 2,
+                h_mid + 0.45,
+                f"{mag}N/m",
+                ha="center",
+                va="bottom",
+                fontsize=10,
+                color="#ff7f0e",
+                fontweight="bold",
+            )
+
+            F_eq = mag * (fin - inicio)
+            ax.arrow(
+                (inicio + fin) / 2,
+                h_mid + 0.8,
+                0,
+                -0.6,
+                head_width=L * 0.015,
+                head_length=0.05,
+                fc="#ff7f0e",
+                ec="#ff7f0e",
+                width=0.002,
+                zorder=15,
+            )
+            ax.text(
+                (inicio + fin) / 2,
+                h_mid + 0.85,
+                f"{F_eq:.1f}N",
+                ha="center",
+                va="bottom",
+                fontsize=10,
+                color="#ff7f0e",
+                fontweight="bold",
+            )
 
         # Dibujar centro de masa si está disponible
         if x_cm is not None:
@@ -759,19 +787,27 @@ class SimuladorVigaMejorado:
             ax.quiver(pos, 0, 0.5, 0, 0, -0.4, color="red", arrow_length_ratio=0.3)
 
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 10)
-            for x_pos in x_dist:
-                ax.quiver(
-                    x_pos,
-                    0,
-                    0.4,
-                    0,
-                    0,
-                    -0.3,
-                    color="orange",
-                    arrow_length_ratio=0.3,
-                    alpha=0.7,
-                )
+            F_eq = mag * (fin - inicio)
+            ax.quiver(
+                (inicio + fin) / 2,
+                0,
+                0.8,
+                0,
+                0,
+                -0.6,
+                color="orange",
+                arrow_length_ratio=0.3,
+            )
+            ax.text(
+                (inicio + fin) / 2,
+                0,
+                0.85,
+                f"{F_eq:.1f}N",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="orange",
+            )
 
         ax.set_xlim(-L * 0.15, L * 1.15)
         ax.set_ylim(-0.8, 0.8)
@@ -818,12 +854,40 @@ class SimuladorVigaMejorado:
             ax.quiver(pos, 0, 0.5, 0, 0, -0.4, color='red', arrow_length_ratio=0.3)
             ax.text(pos, 0, 0.6, f'{mag}N', ha='center', va='bottom', fontsize=8, color='red')
 
-        # Dibujar cargas distribuidas
+        # Dibujar cargas distribuidas como fuerza equivalente
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 10)
-            for x_pos in x_dist:
-                ax.quiver(x_pos, 0, 0.4, 0, 0, -0.3, color='orange', arrow_length_ratio=0.3, alpha=0.7)
-            ax.text((inicio+fin)/2, 0, 0.5, f'{mag}N/m', ha='center', va='bottom', fontsize=8, color='orange')
+            ax.text(
+                (inicio + fin) / 2,
+                0,
+                0.45,
+                f"{mag}N/m",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="orange",
+            )
+
+            F_eq = mag * (fin - inicio)
+            ax.quiver(
+                (inicio + fin) / 2,
+                0,
+                0.8,
+                0,
+                0,
+                -0.6,
+                color="orange",
+                arrow_length_ratio=0.3,
+            )
+            ax.text(
+                (inicio + fin) / 2,
+                0,
+                0.85,
+                f"{F_eq:.1f}N",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="orange",
+            )
 
         # Dibujar centro de masa si está disponible
         if x_cm is not None:
@@ -880,12 +944,37 @@ class SimuladorVigaMejorado:
             ax.text(pos, 0.6, f'{mag}N', ha='center', va='bottom', fontsize=8, color='red')
             
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 50)
-            y_dist = np.full_like(x_dist, 0.4)
-            ax.plot(x_dist, y_dist, 'r-', linewidth=2)
-            for x_pos in x_dist[::5]:
-                ax.arrow(x_pos, 0.4, 0, -0.3, head_width=L*0.008, head_length=0.02, fc='red', ec='red', width=0.001)
-            ax.text((inicio+fin)/2, 0.5, f'{mag}N/m', ha='center', va='bottom', fontsize=8, color='red')
+            ax.text(
+                (inicio + fin) / 2,
+                0.45,
+                f"{mag}N/m",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="red",
+            )
+
+            F_eq = mag * (fin - inicio)
+            ax.arrow(
+                (inicio + fin) / 2,
+                0.75,
+                0,
+                -0.5,
+                head_width=L * 0.015,
+                head_length=0.03,
+                fc="red",
+                ec="red",
+                width=0.002,
+            )
+            ax.text(
+                (inicio + fin) / 2,
+                0.8,
+                f"{F_eq:.1f}N",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="red",
+            )
             
         # Dibujar el par torsor
         par_torsor = self.par_torsor.get()
@@ -946,12 +1035,37 @@ class SimuladorVigaMejorado:
             ax1.text(pos, 0.35, f'{mag}N', ha='center', va='bottom', fontsize=7, color='red')
         
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 50)
-            y_dist = np.full_like(x_dist, 0.2)
-            ax1.plot(x_dist, y_dist, 'r-', linewidth=2)
-            for x_pos in x_dist[::5]:
-                ax1.arrow(x_pos, 0.2, 0, -0.15, head_width=L*0.008, head_length=0.02, fc='red', ec='red', width=0.001)
-            ax1.text((inicio+fin)/2, 0.25, f'{mag}N/m', ha='center', va='bottom', fontsize=7, color='red')
+            ax1.text(
+                (inicio + fin) / 2,
+                0.25,
+                f"{mag}N/m",
+                ha="center",
+                va="bottom",
+                fontsize=7,
+                color="red",
+            )
+
+            F_eq = mag * (fin - inicio)
+            ax1.arrow(
+                (inicio + fin) / 2,
+                0.55,
+                0,
+                -0.35,
+                head_width=L * 0.015,
+                head_length=0.03,
+                fc="red",
+                ec="red",
+                width=0.002,
+            )
+            ax1.text(
+                (inicio + fin) / 2,
+                0.6,
+                f"{F_eq:.1f}N",
+                ha="center",
+                va="bottom",
+                fontsize=7,
+                color="red",
+            )
         
         ax1.set_xlim(-L*0.1, L*1.1)
         ax1.set_ylim(-0.6, 0.7)


### PR DESCRIPTION
## Summary
- hide distributed load graphics and show only the equivalent vector
- clarify README wording about distributed loads

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`

------
https://chatgpt.com/codex/tasks/task_e_684cac97e944832fa845fdf395596c28