### PR TITLE
Simplify distributed load display

### DIFF
--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -699,20 +699,9 @@ class SimuladorVigaMejorado:
             ax.arrow(pos, h+0.5, 0, -0.4, head_width=L*0.015, head_length=0.05, fc='#d62728', ec='#d62728', width=0.002, zorder=15)
             ax.text(pos, h+0.6, f'{mag}N', ha='center', va='bottom', fontsize=10, color='#d62728', fontweight='bold')
 
-        # Dibujar cargas distribuidas
+        # Dibujar cargas distribuidas como carga puntual equivalente
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 50)
-            y_dist = h_inicial + (h_final - h_inicial) * x_dist / L + 0.4
-            ax.plot(x_dist, y_dist, '#ff7f0e', linewidth=2, zorder=15)
-            for x_pos in x_dist[::5]:
-                h = h_inicial + (h_final - h_inicial) * x_pos / L
-                ax.arrow(x_pos, h+0.4, 0, -0.3, head_width=L*0.008, head_length=0.02, fc='#ff7f0e', ec='#ff7f0e', width=0.001, zorder=15)
-
-            # Mostrar magnitud distribuida
             h_mid = h_inicial + (h_final - h_inicial) * ((inicio+fin)/2) / L
-            ax.text((inicio+fin)/2, h_mid+0.45, f'{mag}N/m', ha='center', va='bottom', fontsize=10, color='#ff7f0e', fontweight='bold')
-
-            # Vector equivalente de la carga distribuida
             F_eq = mag * (fin - inicio)
             ax.arrow((inicio+fin)/2, h_mid+0.8, 0, -0.6, head_width=L*0.015, head_length=0.05,
                      fc='#ff7f0e', ec='#ff7f0e', width=0.002, zorder=15)
@@ -769,20 +758,6 @@ class SimuladorVigaMejorado:
             ax.quiver(pos, 0, 0.5, 0, 0, -0.4, color="red", arrow_length_ratio=0.3)
 
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 10)
-            for x_pos in x_dist:
-                ax.quiver(
-                    x_pos,
-                    0,
-                    0.4,
-                    0,
-                    0,
-                    -0.3,
-                    color="orange",
-                    arrow_length_ratio=0.3,
-                    alpha=0.7,
-                )
-            # Vector equivalente
             F_eq = mag * (fin - inicio)
             ax.quiver((inicio+fin)/2, 0, 0.8, 0, 0, -0.6, color="orange", arrow_length_ratio=0.3)
             ax.text((inicio+fin)/2, 0, 0.85, f"{F_eq:.1f}N", ha="center", va="bottom", fontsize=8, color="orange")
@@ -832,14 +807,8 @@ class SimuladorVigaMejorado:
             ax.quiver(pos, 0, 0.5, 0, 0, -0.4, color='red', arrow_length_ratio=0.3)
             ax.text(pos, 0, 0.6, f'{mag}N', ha='center', va='bottom', fontsize=8, color='red')
 
-        # Dibujar cargas distribuidas
+        # Dibujar cargas distribuidas como carga puntual equivalente
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 10)
-            for x_pos in x_dist:
-                ax.quiver(x_pos, 0, 0.4, 0, 0, -0.3, color='orange', arrow_length_ratio=0.3, alpha=0.7)
-            ax.text((inicio+fin)/2, 0, 0.45, f'{mag}N/m', ha='center', va='bottom', fontsize=8, color='orange')
-
-            # Vector equivalente en 3D
             F_eq = mag * (fin - inicio)
             ax.quiver((inicio+fin)/2, 0, 0.8, 0, 0, -0.6, color='orange', arrow_length_ratio=0.3)
             ax.text((inicio+fin)/2, 0, 0.85, f'{F_eq:.1f}N', ha='center', va='bottom', fontsize=8, color='orange')
@@ -899,14 +868,6 @@ class SimuladorVigaMejorado:
             ax.text(pos, 0.6, f'{mag}N', ha='center', va='bottom', fontsize=8, color='red')
             
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 50)
-            y_dist = np.full_like(x_dist, 0.4)
-            ax.plot(x_dist, y_dist, 'r-', linewidth=2)
-            for x_pos in x_dist[::5]:
-                ax.arrow(x_pos, 0.4, 0, -0.3, head_width=L*0.008, head_length=0.02, fc='red', ec='red', width=0.001)
-            ax.text((inicio+fin)/2, 0.45, f'{mag}N/m', ha='center', va='bottom', fontsize=8, color='red')
-
-            # Vector equivalente de la carga distribuida
             F_eq = mag * (fin - inicio)
             ax.arrow((inicio+fin)/2, 0.75, 0, -0.5, head_width=L*0.015, head_length=0.03,
                      fc='red', ec='red', width=0.002)
@@ -971,14 +932,6 @@ class SimuladorVigaMejorado:
             ax1.text(pos, 0.35, f'{mag}N', ha='center', va='bottom', fontsize=7, color='red')
         
         for inicio, fin, mag in self.cargas_distribuidas:
-            x_dist = np.linspace(inicio, fin, 50)
-            y_dist = np.full_like(x_dist, 0.2)
-            ax1.plot(x_dist, y_dist, 'r-', linewidth=2)
-            for x_pos in x_dist[::5]:
-                ax1.arrow(x_pos, 0.2, 0, -0.15, head_width=L*0.008, head_length=0.02, fc='red', ec='red', width=0.001)
-            ax1.text((inicio+fin)/2, 0.25, f'{mag}N/m', ha='center', va='bottom', fontsize=7, color='red')
-
-            # Vector equivalente
             F_eq = mag * (fin - inicio)
             ax1.arrow((inicio+fin)/2, 0.55, 0, -0.35, head_width=L*0.015, head_length=0.03, fc='red', ec='red', width=0.002)
             ax1.text((inicio+fin)/2, 0.6, f'{F_eq:.1f}N', ha='center', va='bottom', fontsize=7, color='red')


### PR DESCRIPTION
## Summary
- remove line/arrow drawing for distributed loads
- show only their equivalent point load vector in 2D, 3D and diagram views

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`
- `python3 simulador_viga_mejorado.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684cc79e0d14832f98f8878a9fcf3ea0