### PR TITLE
Add Plotly diagrams and 3D view

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,5 @@ También se incluye un `Dockerfile` para levantar la aplicación de manera senci
 docker build -t simulador-viga .
 docker run -p 8000:8000 simulador-viga
 ```
+
+La página web ahora incluye gráficas interactivas con **Plotly.js** para los diagramas de cortante, momento y torsión, así como una vista básica en 3D de la viga implementada con **Three.js**.

--- a/backend/beam.py
+++ b/backend/beam.py
@@ -80,8 +80,8 @@ def generar_diagramas(
     posicion_apoyo_c: float = 0.0,
     par_torsor: float = 0.0,
     num_puntos: int = 500,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return x positions, shear force and bending moment diagrams."""
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return x positions, shear force, bending moment and torsion diagrams."""
     RA, RB, RC = calcular_reacciones(
         longitud,
         cargas_puntuales,
@@ -94,6 +94,7 @@ def generar_diagramas(
     x = np.linspace(0, longitud, num_puntos)
     cortante = np.zeros_like(x)
     momento = np.zeros_like(x)
+    torsion = np.full_like(x, par_torsor)
 
     for i, xi in enumerate(x):
         V = RA
@@ -125,8 +126,7 @@ def generar_diagramas(
 
         cortante[i] = V
         momento[i] = M
-
-    return x, cortante, momento
+    return x, cortante, momento, torsion
 
 
 def par_en_punto(

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,7 +54,7 @@ def api_centro_masa(data: BeamRequest):
 
 @app.post("/generar_diagramas")
 def api_generar_diagramas(data: BeamRequest):
-    x, cortante, momento = beam.generar_diagramas(
+    x, cortante, momento, torsion = beam.generar_diagramas(
         data.longitud,
         [(c.pos, c.mag) for c in data.cargas_puntuales],
         [(d.inicio, d.fin, d.mag) for d in data.cargas_distribuidas],
@@ -66,6 +66,7 @@ def api_generar_diagramas(data: BeamRequest):
         "x": x.tolist(),
         "cortante": cortante.tolist(),
         "momento": momento.tolist(),
+        "torsion": torsion.tolist(),
     }
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,17 +7,21 @@
   <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-2.26.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.153/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.153/examples/js/controls/OrbitControls.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3/dist/tailwind.min.css" rel="stylesheet" />
 </head>
 <body class="bg-gray-100 text-gray-900">
   <div id="root" class="p-4"></div>
 
   <script type="text/babel">
-    const { useState } = React;
+    const { useState, useEffect } = React;
 
     function App() {
       const [longitud, setLongitud] = useState(10);
       const [resultado, setResultado] = useState(null);
+      const [diagramas, setDiagramas] = useState(null);
 
       async function calcular() {
         const data = { longitud, cargas_puntuales: [], cargas_distribuidas: [] };
@@ -25,17 +29,58 @@
         setResultado(res.data);
       }
 
+      async function mostrarDiagramas() {
+        const data = { longitud, cargas_puntuales: [], cargas_distribuidas: [] };
+        const res = await axios.post('/generar_diagramas', data);
+        setDiagramas(res.data);
+      }
+
+      useEffect(() => {
+        if (!diagramas) return;
+        const { x, cortante, momento, torsion } = diagramas;
+        Plotly.newPlot('cortante', [{ x, y: cortante }], { title: 'Diagrama de Cortante' });
+        Plotly.newPlot('momento', [{ x, y: momento }], { title: 'Diagrama de Momento' });
+        Plotly.newPlot('torsion', [{ x, y: torsion }], { title: 'Diagrama de Torsión' });
+      }, [diagramas]);
+
+      useEffect(() => {
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        const container = document.getElementById('view3d');
+        renderer.setSize(300, 300);
+        container.appendChild(renderer.domElement);
+        const controls = new THREE.OrbitControls(camera, renderer.domElement);
+        const geometry = new THREE.BoxGeometry(longitud, 0.2, 0.2);
+        const material = new THREE.MeshNormalMaterial();
+        const cube = new THREE.Mesh(geometry, material);
+        scene.add(cube);
+        camera.position.z = 5;
+        function animate() {
+          requestAnimationFrame(animate);
+          renderer.render(scene, camera);
+        }
+        animate();
+      }, []);
+
       return (
-        <div className="max-w-xl mx-auto">
-          <h1 className="text-2xl font-bold mb-4">Simulador de Viga</h1>
-          <label className="block mb-2">
+        <div className="max-w-xl mx-auto space-y-4">
+          <h1 className="text-2xl font-bold">Simulador de Viga</h1>
+          <label className="block">
             Longitud (m)
             <input type="number" value={longitud} onChange={e => setLongitud(+e.target.value)} className="border p-1 ml-2" />
           </label>
-          <button onClick={calcular} className="bg-blue-500 text-white px-4 py-2 rounded">Calcular Reacciones</button>
+          <div className="space-x-2">
+            <button onClick={calcular} className="bg-blue-500 text-white px-4 py-2 rounded">Calcular Reacciones</button>
+            <button onClick={mostrarDiagramas} className="bg-green-500 text-white px-4 py-2 rounded">Mostrar Diagramas</button>
+          </div>
           {resultado && (
-            <pre className="mt-4 bg-white p-2 border rounded">{JSON.stringify(resultado, null, 2)}</pre>
+            <pre className="bg-white p-2 border rounded">{JSON.stringify(resultado, null, 2)}</pre>
           )}
+          <div id="cortante" className="bg-white p-2 border rounded"></div>
+          <div id="momento" className="bg-white p-2 border rounded mt-4"></div>
+          <div id="torsion" className="bg-white p-2 border rounded mt-4"></div>
+          <div id="view3d" className="mt-4"></div>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- extend backend diagrams endpoint to include torsion information
- expose torsion in FastAPI response
- show interactive diagrams with Plotly in React frontend
- add basic Three.js 3D beam view
- document new web features in README

## Testing
- `python -m py_compile backend/*.py simulador_viga_mejorado.py`

------
https://chatgpt.com/codex/tasks/task_e_684e6e333e38832f9efc6e4c295f0043