### PR TITLE
Add web version with improved charts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Simulador de Viga Web</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="p-3">
+  <h1 class="text-center mb-4">Simulador de Viga Web</h1>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-4">
+        <h5>Configuración de la Viga</h5>
+      <div class="mb-2">
+        <label class="form-label">Longitud (m)</label>
+        <input type="number" id="longitud" class="form-control" value="10">
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Apoyo A</label>
+        <select id="apoyoA" class="form-select">
+          <option value="Fijo">Fijo</option>
+          <option value="Móvil">Móvil</option>
+        </select>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Apoyo B</label>
+        <select id="apoyoB" class="form-select">
+          <option value="Móvil">Móvil</option>
+          <option value="Fijo">Fijo</option>
+        </select>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Apoyo C</label>
+        <select id="apoyoC" class="form-select">
+          <option value="Ninguno" selected>Ninguno</option>
+          <option value="Fijo">Fijo</option>
+          <option value="Móvil">Móvil</option>
+        </select>
+        <input type="number" id="posC" class="form-control mt-1" placeholder="Posición C (m)" value="5">
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Par Torsor (N·m)</label>
+        <input type="number" id="torsor" class="form-control" value="0">
+      </div>
+      <div class="mb-2">
+        <button id="calcReacciones" class="btn btn-primary w-100">Calcular Reacciones</button>
+        <button id="calcDiagramas" class="btn btn-info w-100 mt-2">Calcular Diagramas</button>
+        <button id="limpiar" class="btn btn-secondary w-100 mt-2">Limpiar</button>
+      </div>
+      <hr>
+      <h5>Añadir Carga Puntual</h5>
+      <div class="input-group mb-2">
+        <input type="number" id="posCarga" class="form-control" placeholder="Posición (m)">
+        <input type="number" id="magCarga" class="form-control" placeholder="Magnitud (N)">
+        <button id="addCarga" class="btn btn-success">Agregar</button>
+      </div>
+      <h5>Añadir Carga Distribuida</h5>
+      <div class="input-group mb-2">
+        <input type="number" id="inicioDist" class="form-control" placeholder="Inicio (m)">
+        <input type="number" id="finDist" class="form-control" placeholder="Fin (m)">
+        <input type="number" id="magDist" class="form-control" placeholder="N/m">
+        <button id="addDist" class="btn btn-success">Agregar</button>
+      </div>
+    </div>
+    <div class="col-md-8">
+      <ul class="nav nav-tabs mb-3" id="chartTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" id="beam-tab" data-bs-toggle="tab" data-bs-target="#beam" type="button" role="tab">Viga</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="shear-tab" data-bs-toggle="tab" data-bs-target="#shear" type="button" role="tab">Cortante</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="moment-tab" data-bs-toggle="tab" data-bs-target="#moment" type="button" role="tab">Momento</button>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div class="tab-pane fade show active" id="beam" role="tabpanel" aria-labelledby="beam-tab">
+          <canvas id="beamChart" height="200"></canvas>
+        </div>
+        <div class="tab-pane fade" id="shear" role="tabpanel" aria-labelledby="shear-tab">
+          <canvas id="shearChart" height="200"></canvas>
+        </div>
+        <div class="tab-pane fade" id="moment" role="tabpanel" aria-labelledby="moment-tab">
+          <canvas id="momentChart" height="200"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row mt-3">
+    <div class="col">
+      <pre id="resultado" class="border p-2"></pre>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,115 @@
+let cargasPuntuales = [];
+let cargasDistribuidas = [];
+let beamChart, shearChart, momentChart;
+let RA = 0, RB = 0, RC = 0;
+let L = 10, torsor = 0, tipoC = 'Ninguno', c = 0;
+
+function agregarCarga() {
+  const pos = parseFloat(document.getElementById('posCarga').value);
+  const mag = parseFloat(document.getElementById('magCarga').value);
+  if (isNaN(pos) || isNaN(mag)) return;
+  cargasPuntuales.push({pos, mag});
+}
+
+function agregarDist() {
+  const inicio = parseFloat(document.getElementById('inicioDist').value);
+  const fin = parseFloat(document.getElementById('finDist').value);
+  const mag = parseFloat(document.getElementById('magDist').value);
+  if (isNaN(inicio) || isNaN(fin) || isNaN(mag) || fin <= inicio) return;
+  cargasDistribuidas.push({inicio, fin, mag});
+}
+
+document.getElementById('addCarga').onclick = () => { agregarCarga(); };
+document.getElementById('addDist').onclick = () => { agregarDist(); };
+document.getElementById('limpiar').onclick = () => {
+  cargasPuntuales = [];
+  cargasDistribuidas = [];
+  actualizarGraficos([], [], []);
+  document.getElementById('resultado').textContent = '';
+};
+
+document.getElementById('calcReacciones').onclick = () => { calcularReacciones(); };
+document.getElementById('calcDiagramas').onclick = () => { calcularDiagramas(); };
+
+function leerDatos(){
+  L = parseFloat(document.getElementById('longitud').value);
+  torsor = parseFloat(document.getElementById('torsor').value);
+  tipoC = document.getElementById('apoyoC').value;
+  c = parseFloat(document.getElementById('posC').value);
+}
+
+function calcularReacciones() {
+  leerDatos();
+
+  let sumaF = 0;
+  let sumaM = 0;
+  cargasPuntuales.forEach(cg => { sumaF += cg.mag; sumaM += cg.mag * cg.pos; });
+  cargasDistribuidas.forEach(cd => { let F = cd.mag * (cd.fin-cd.inicio); let cent = cd.inicio + (cd.fin-cd.inicio)/2; sumaF += F; sumaM += F * cent; });
+
+  RA = 0;
+  RB = 0;
+  RC = 0;
+  if (tipoC === 'Ninguno') {
+    RB = (sumaM + torsor) / L;
+    RA = sumaF - RB;
+  } else {
+    RB = ((sumaM + torsor) - c * sumaF / 2) / (L - c);
+    RA = (sumaF - RB) / 2;
+    RC = RA;
+  }
+
+  const resultado =
+`RA = ${RA.toFixed(2)} N\nRB = ${RB.toFixed(2)} N${tipoC!=='Ninguno'?`\nRC = ${RC.toFixed(2)} N`:''}`;
+  document.getElementById('resultado').textContent = resultado;
+};
+
+function calcularDiagramas(){
+  calcularReacciones();
+  const puntos = 200;
+  const x = [];
+  const V = [];
+  const M = [];
+  for (let i = 0; i <= puntos; i++) {
+    const xi = L * i / puntos;
+    let v = RA;
+    let m = RA * xi + torsor;
+    if (tipoC !== 'Ninguno' && xi >= c) { v += RC; m += RC * (xi - c); }
+    if (xi >= L) { v += RB; m += RB * (xi - L); }
+    cargasPuntuales.forEach(cp => { if (xi > cp.pos) { v -= cp.mag; m -= cp.mag * (xi - cp.pos); } });
+    cargasDistribuidas.forEach(cd => {
+      if (xi > cd.inicio) {
+        if (xi <= cd.fin) {
+          let l = xi - cd.inicio; v -= cd.mag * l; m -= cd.mag * l * l / 2;
+        } else {
+          let lt = cd.fin - cd.inicio; v -= cd.mag * lt; m -= cd.mag * lt * (xi - (cd.inicio + lt / 2));
+        }
+      }
+    });
+    x.push(xi);
+    V.push(v);
+    M.push(m);
+  }
+  actualizarGraficos(x, V, M);
+}
+
+function actualizarGraficos(x, V, M){
+  if(beamChart){beamChart.destroy(); shearChart.destroy(); momentChart.destroy();}
+  const beamCtx = document.getElementById('beamChart');
+  const shearCtx = document.getElementById('shearChart');
+  const momentCtx = document.getElementById('momentChart');
+  beamChart = new Chart(beamCtx, {
+    type: 'line',
+    data: {labels:x, datasets:[{label:'Viga', data: Array(x.length).fill(0), borderColor:'black', borderWidth:4, fill:false}]},
+    options:{scales:{y:{beginAtZero:true}}}
+  });
+  shearChart = new Chart(shearCtx, {
+    type:'line',
+    data:{labels:x, datasets:[{label:'Cortante', data:V, borderColor:'blue', backgroundColor:'rgba(0,0,255,0.3)'}]},
+    options:{plugins:{legend:{display:false}}, scales:{y:{beginAtZero:false}}}
+  });
+  momentChart = new Chart(momentCtx, {
+    type:'line',
+    data:{labels:x, datasets:[{label:'Momento', data:M, borderColor:'red', backgroundColor:'rgba(255,0,0,0.3)'}]},
+    options:{plugins:{legend:{display:false}}, scales:{y:{beginAtZero:false}}}
+  });
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,3 @@
+body { background-color: #f8f9fa; }
+pre { background-color: #fff; }
+canvas { background-color: #fff; border: 1px solid #dee2e6; }


### PR DESCRIPTION
## Summary
- create `web` folder with an HTML interface
- add Chart.js based diagrams for shear and moment calculations
- modernize web layout with Bootstrap tabs and separate buttons

## Testing
- `python -m py_compile simulador_viga_mejorado.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850e7ffd6c4832fb323d8eea63d18f3