### PR TITLE
Improve startup by adding dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,13 @@ El valor se mostrará en el registro y en los diagramas.
 ### 10. Uso
 
 1. Clona este repositorio o descarga el código.
-2. Asegúrate de tener **Python 3**, `tkinter`, `matplotlib` y `numpy` instalados.
-   Para un aspecto moderno instala opcionalmente `ttkbootstrap` con `pip install ttkbootstrap`.
+2. Asegúrate de tener **Python 3** y las dependencias necesarias. Ejecuta:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Esto instalará `matplotlib`, `numpy` y opcionalmente `ttkbootstrap`.
+   Si alguna dependencia falta al ejecutar el programa, verás un mensaje con
+   instrucciones para instalarla.
 3. Ejecuta `python3 simulador_viga_mejorado.py`.
 4. Configura la viga y agrega las cargas necesarias.
 5. Usa **Par en Punto** para consultar el momento torsor si lo necesitas.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+numpy
+ttkbootstrap

--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -1,3 +1,4 @@
+import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 
@@ -7,11 +8,35 @@ try:
 except ImportError:
     ttkb = None
     BOOTSTRAP_AVAILABLE = False
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-from matplotlib.animation import FuncAnimation
-import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
+def missing_dependency(dep: str):
+    """Display an error message and exit when a dependency is missing."""
+    try:
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror(
+            "Dependencia faltante",
+            f"No se encontró la biblioteca '{dep}'.\nInstálala ejecutando 'pip install {dep}'.",
+        )
+        root.destroy()
+    except tk.TclError:
+        # Entornos sin interfaz gráfica
+        print(
+            f"Error: No se encontró la biblioteca '{dep}'. Instálala ejecutando 'pip install {dep}'."
+        )
+    sys.exit(1)
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+    from matplotlib.animation import FuncAnimation
+    from mpl_toolkits.mplot3d import Axes3D
+except ImportError:
+    missing_dependency("matplotlib")
+
+try:
+    import numpy as np
+except ImportError:
+    missing_dependency("numpy")
 
 class SimuladorVigaMejorado:
     def __init__(self, root, bootstrap=False):


### PR DESCRIPTION
## Summary
- handle missing `matplotlib` and `numpy` with a clear message
- provide `requirements.txt` for easy dependency installation
- update README with install instructions

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`

------
https://chatgpt.com/codex/tasks/task_e_6850f57d57c4832f8f6b3ed6c35c20d4