### PR TITLE
Revert to original base

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 Este repositorio contiene un programa escrito en **Python** para analizar y visualizar el comportamiento de una viga mecánica. Utiliza **Tkinter** para la interfaz gráfica y, si está disponible, el paquete **`ttkbootstrap`** para darle un aspecto mucho más moderno. Las gráficas se generan con `matplotlib`, los cálculos con `numpy` y la vista en 3D con `mpl_toolkits`.
 
-La versión anterior incluía una carpeta con archivos HTML y JavaScript. Se eliminó por completo para mantener solo la aplicación de escritorio basada en Python.
-
 ### 1. Estructura del código
 
 El programa está estructurado en una **clase principal llamada `SimuladorVigaMejorado`**, donde se encuentra todo lo relacionado con el simulador. Dentro de esta clase se inicializa la ventana y se organizan todas las pestañas y botones.
@@ -104,24 +102,9 @@ El valor se mostrará en el registro y en los diagramas.
 ### 10. Uso
 
 1. Clona este repositorio o descarga el código.
-2. Asegúrate de tener **Python 3** y las dependencias necesarias. Ejecuta:
-   ```bash
-   pip install -r requirements.txt
-   ```
-   Esto instalará `matplotlib`, `numpy` y opcionalmente `ttkbootstrap`.
-   Si alguna dependencia falta al ejecutar el programa, verás un mensaje con
-   instrucciones para instalarla.
+2. Asegúrate de tener **Python 3**, `tkinter`, `matplotlib` y `numpy` instalados.
+   Para un aspecto moderno instala opcionalmente `ttkbootstrap` con `pip install ttkbootstrap`.
 3. Ejecuta `python3 simulador_viga_mejorado.py`.
 4. Configura la viga y agrega las cargas necesarias.
 5. Usa **Par en Punto** para consultar el momento torsor si lo necesitas.
 6. Revisa los resultados en la pestaña de **Resultados**.
-
-### 11. Compilar la aplicación a `.exe`
-
-Para generar un archivo ejecutable en Windows puedes usar **PyInstaller**:
-
-1. Instala PyInstaller con `pip install pyinstaller`.
-2. Ejecuta `pyinstaller --onefile simulador_viga_mejorado.py`.
-3. El ejecutable aparecerá en la carpeta `dist/` con el nombre `simulador_viga_mejorado.exe`.
-
-En este repositorio se incluye un directorio `dist/` como lugar sugerido para colocar dicho archivo.

--- a/dist/simulador_viga_mejorado.exe
+++ b/dist/simulador_viga_mejorado.exe
@@ -1,1 +1,0 @@
-Placeholder for Windows executable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-matplotlib
-numpy
-ttkbootstrap

--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -1,4 +1,3 @@
-import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 
@@ -8,35 +7,11 @@ try:
 except ImportError:
     ttkb = None
     BOOTSTRAP_AVAILABLE = False
-def missing_dependency(dep: str):
-    """Display an error message and exit when a dependency is missing."""
-    try:
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showerror(
-            "Dependencia faltante",
-            f"No se encontró la biblioteca '{dep}'.\nInstálala ejecutando 'pip install {dep}'.",
-        )
-        root.destroy()
-    except tk.TclError:
-        # Entornos sin interfaz gráfica
-        print(
-            f"Error: No se encontró la biblioteca '{dep}'. Instálala ejecutando 'pip install {dep}'."
-        )
-    sys.exit(1)
-
-try:
-    import matplotlib.pyplot as plt
-    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-    from matplotlib.animation import FuncAnimation
-    from mpl_toolkits.mplot3d import Axes3D
-except ImportError:
-    missing_dependency("matplotlib")
-
-try:
-    import numpy as np
-except ImportError:
-    missing_dependency("numpy")
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+from matplotlib.animation import FuncAnimation
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D
 
 class SimuladorVigaMejorado:
     def __init__(self, root, bootstrap=False):


### PR DESCRIPTION
## Summary
- remove Windows executable and requirements file
- revert README to base text
- revert Python program to base without dependency checks

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`

------
https://chatgpt.com/codex/tasks/task_e_6850f6733e40832f9144452207c99adf