### PR TITLE
Add web editor for irregular shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ El programa está estructurado en una **clase principal llamada `SimuladorVigaMe
 La ventana está dividida en **tres pestañas principales**:
 
 * **Configuración y cargas**: aquí se puede cambiar la longitud de la viga, los tipos de apoyos (fijo, móvil o ninguno), y agregar cargas (puntuales o distribuidas).
-* **Sección y formas**: permite calcular propiedades geométricas como el centro de gravedad y momento de inercia. También se pueden dibujar formas irregulares (triángulos, círculos y rectángulos) para analizar cómo afectan.
+* **Sección y formas**: permite calcular propiedades geométricas como el centro de gravedad y momento de inercia. También se pueden dibujar formas irregulares (triángulos, círculos y rectángulos) para analizar cómo afectan. Ahora incluye un botón **Abrir Opciones Web** que lanza un editor HTML para manipular las figuras con mayor precisión.
 * **Resultados**: en esta pestaña se muestran los gráficos, los resultados de las reacciones, los diagramas de momento y cortante, y también la animación 3D si se activa.
 
 ---

--- a/figuras_irregulares.html
+++ b/figuras_irregulares.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Editor de Figuras Irregulares</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 20px; }
+  canvas { border: 1px solid #ccc; cursor: crosshair; }
+  #controls { margin-bottom: 10px; }
+  label { margin-right: 5px; }
+</style>
+</head>
+<body>
+<h2>Editor de Figuras Irregulares</h2>
+<div id="controls">
+  <label>Tipo:</label>
+  <select id="shape">
+    <option value="rect">Rectángulo</option>
+    <option value="tri">Triángulo</option>
+    <option value="circ">Círculo</option>
+  </select>
+  <label>Ancho:</label>
+  <input type="number" id="width" value="50" style="width:60px">
+  <label>Alto/Radio:</label>
+  <input type="number" id="height" value="50" style="width:60px">
+  <button id="add">Agregar</button>
+</div>
+<canvas id="canvas" width="600" height="400"></canvas>
+<script>
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+let shapes = [];
+let dragging = null;
+let offsetX = 0;
+let offsetY = 0;
+function drawShapes(){
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  shapes.forEach(s => {
+    ctx.beginPath();
+    if(s.type==='rect') ctx.rect(s.x, s.y, s.w, s.h);
+    if(s.type==='tri') {
+      ctx.moveTo(s.x, s.y+s.h); ctx.lineTo(s.x+s.w, s.y+s.h); ctx.lineTo(s.x, s.y); ctx.closePath();
+    }
+    if(s.type==='circ') ctx.arc(s.x, s.y, s.w/2, 0, Math.PI*2);
+    ctx.stroke();
+  });
+}
+canvas.addEventListener('mousedown', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  for(let i=shapes.length-1;i>=0;i--){
+    const s=shapes[i];
+    if(s.type==='rect' && x>=s.x && x<=s.x+s.w && y>=s.y && y<=s.y+s.h){
+      dragging=i; offsetX=x-s.x; offsetY=y-s.y; return; }
+    if(s.type==='tri'){
+      const b = s.y+s.h; const area = Math.abs((s.x*(b-y)+(s.x+s.w)* (y-s.y)+x*(s.y-b))/2);
+      if(area<=s.w*s.h/2){ dragging=i; offsetX=x-s.x; offsetY=y-s.y; return; }
+    }
+    if(s.type==='circ' && Math.hypot(x-s.x,y-s.y)<=s.w/2){ dragging=i; offsetX=x-s.x; offsetY=y-s.y; return; }
+  }
+});
+canvas.addEventListener('mousemove', e => {
+  if(dragging===null) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const s = shapes[dragging];
+  s.x = x - offsetX;
+  s.y = y - offsetY;
+  drawShapes();
+});
+canvas.addEventListener('mouseup', ()=>{ dragging=null; });
+document.getElementById('add').addEventListener('click', ()=>{
+  const type=document.getElementById('shape').value;
+  const w=parseFloat(document.getElementById('width').value);
+  const h=parseFloat(document.getElementById('height').value);
+  shapes.push({type,x:50,y:50,w,w,h});
+  drawShapes();
+});
+</script>
+</body>
+</html>

--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -12,6 +12,8 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolb
 from matplotlib.animation import FuncAnimation
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
+import webbrowser
+import os
 
 class SimuladorVigaMejorado:
     def __init__(self, root, bootstrap=False):
@@ -1270,10 +1272,10 @@ class SimuladorVigaMejorado:
         ttk.Button(frame_formas, text="Calcular CG", command=self.calcular_cg_formas).grid(row=3, column=2, columnspan=2, pady=5)
         ttk.Button(frame_formas, text="Limpiar Lienzo", command=self.limpiar_lienzo_formas).grid(row=4, column=0, columnspan=2, pady=5)
         ttk.Button(frame_formas, text="Ampliar Lienzo", command=self.ampliar_lienzo_formas).grid(row=4, column=2, columnspan=2, pady=5)
-
-        ttk.Label(frame_formas, text="⚡ También puede hacer clic en el lienzo para agregar").grid(row=5, column=0, columnspan=4, pady=2)
+        ttk.Button(frame_formas, text="Abrir Opciones Web", command=self.abrir_opciones_figuras_html).grid(row=4, column=4, pady=5)
+        ttk.Label(frame_formas, text="⚡ También puede hacer clic en el lienzo para agregar").grid(row=5, column=0, columnspan=5, pady=2)
         self.canvas_formas = tk.Canvas(frame_formas, width=400, height=300, bg="white")
-        self.canvas_formas.grid(row=6, column=0, columnspan=4, pady=5)
+        self.canvas_formas.grid(row=6, column=0, columnspan=5, pady=5)
         self.canvas_formas.bind("<Button-1>", self.iniciar_accion_formas)
         self.canvas_formas.bind("<B1-Motion>", self.arrastrar_forma)
         self.canvas_formas.bind("<ButtonRelease-1>", self.soltar_forma)
@@ -1287,10 +1289,10 @@ class SimuladorVigaMejorado:
         self.dibujar_cuadricula(self.canvas_formas)
 
         self.coord_label = ttk.Label(frame_formas, text="x=0, y=0")
-        self.coord_label.grid(row=7, column=0, columnspan=4, pady=2)
+        self.coord_label.grid(row=7, column=0, columnspan=5, pady=2)
 
         self.cg_label = ttk.Label(frame_formas, text="CG: -")
-        self.cg_label.grid(row=8, column=0, columnspan=4, pady=2)
+        self.cg_label.grid(row=8, column=0, columnspan=5, pady=2)
 
     def agregar_forma(self):
         try:
@@ -1593,6 +1595,11 @@ class SimuladorVigaMejorado:
 
         self.coord_label_ampliado = ttk.Label(self.ventana_lienzo, text="x=0, y=0")
         self.coord_label_ampliado.pack()
+
+    def abrir_opciones_figuras_html(self):
+        """Abre la interfaz HTML para editar figuras irregulares en el navegador."""
+        ruta = os.path.join(os.path.dirname(__file__), "figuras_irregulares.html")
+        webbrowser.open(f"file://{os.path.abspath(ruta)}")
 
     def crear_seccion_resultados(self, parent):
         frame_resultados = ttk.LabelFrame(parent, text="Resultados")


### PR DESCRIPTION
## Summary
- add simple HTML editor for irregular shapes
- open the HTML from a new "Abrir Opciones Web" button
- document the new button in the README

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`
- `python3 simulador_viga_mejorado.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6850f7a3f76c832fa0f7b16a84fc347f