### PR TITLE
Add backend integration and enhance web editor

### DIFF
--- a/web_editor/README.md
+++ b/web_editor/README.md
@@ -1,2 +1,16 @@
 Esta carpeta contiene el editor web utilizado para crear y modificar figuras irregulares.
 El archivo `figuras_irregulares.html` permite dibujar rectángulos, triángulos, círculos y flechas sobre un lienzo con cuadriculado numerado.
+Ahora también calcula el centro de gravedad (CG) de las figuras de dos formas:
+
+1. **CG Local**: realiza el cálculo en el propio navegador.
+2. **CG Backend**: envía las figuras a `server.py` para que el backend realice el cálculo.
+
+Para iniciar el servidor backend ejecuta:
+
+```bash
+python3 server.py
+```
+
+Luego abre `figuras_irregulares.html` en tu navegador. Con el botón *CG Backend* se consultará el resultado al servidor.
+
+Las figuras pueden moverse con el botón izquierdo del ratón y redimensionarse manteniendo presionado el botón derecho. Con `Ctrl` + rueda del ratón se modifica el grosor de la línea seleccionada.

--- a/web_editor/figuras_irregulares.html
+++ b/web_editor/figuras_irregulares.html
@@ -25,12 +25,17 @@
   <input type="number" id="width" value="50" style="width:60px">
   <label>Alto/Radio:</label>
   <input type="number" id="height" value="50" style="width:60px">
+  <label>Grosor:</label>
+  <input type="number" id="thickness" value="2" style="width:40px">
   <button id="add">Agregar</button>
-  <button id="delete">Borrar Seleccion</button>
+  <button id="delete">Borrar Selección</button>
   <button id="bigger">Aumentar</button>
   <button id="smaller">Reducir</button>
+  <button id="cgLocal">CG Local</button>
+  <button id="cgBack">CG Backend</button>
 </div>
 <canvas id="canvas" width="600" height="400"></canvas>
+<div id="result"></div>
 <script>
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
@@ -39,6 +44,9 @@ let dragging = null;
 let offsetX = 0;
 let offsetY = 0;
 let selected = null;
+let resizing = null;
+let startW = 0;
+let startH = 0;
 const gridSize = 50;
 
 function drawGrid(){
@@ -80,6 +88,7 @@ function drawShapes(){
       ctx.moveTo(s.x+s.w, s.y+s.h);
       ctx.lineTo(s.x+s.w-head*Math.cos(angle+Math.PI/6), s.y+s.h-head*Math.sin(angle+Math.PI/6));
     }
+    ctx.lineWidth=s.thickness||2;
     ctx.strokeStyle = (i===selected) ? 'red' : 'black';
     ctx.stroke();
     ctx.strokeStyle = 'black';
@@ -93,35 +102,58 @@ canvas.addEventListener('mousedown', e => {
   for(let i=shapes.length-1;i>=0;i--){
     const s=shapes[i];
     if(s.type==='rect' && x>=s.x && x<=s.x+s.w && y>=s.y && y<=s.y+s.h){
+      if(e.button===2){ resizing=i; startW=s.w; startH=s.h; return; }
       dragging=i; selected=i; offsetX=x-s.x; offsetY=y-s.y; return; }
     if(s.type==='tri'){
-      const b = s.y+s.h; const area = Math.abs((s.x*(b-y)+(s.x+s.w)* (y-s.y)+x*(s.y-b))/2);
-      if(area<=s.w*s.h/2){ dragging=i; selected=i; offsetX=x-s.x; offsetY=y-s.y; return; }
+      const b=s.y+s.h; const area=Math.abs((s.x*(b-y)+(s.x+s.w)*(y-s.y)+x*(s.y-b))/2);
+      if(area<=s.w*s.h/2){
+        if(e.button===2){ resizing=i; startW=s.w; startH=s.h; return; }
+        dragging=i; selected=i; offsetX=x-s.x; offsetY=y-s.y; return; }
     }
     if(s.type==='circ' && Math.hypot(x-s.x,y-s.y)<=s.w/2){ dragging=i; selected=i; offsetX=x-s.x; offsetY=y-s.y; return; }
     if(s.type==='arrow'){
       const minX=Math.min(s.x,s.x+s.w); const maxX=Math.max(s.x,s.x+s.w);
       const minY=Math.min(s.y,s.y+s.h); const maxY=Math.max(s.y,s.y+s.h);
-      if(x>=minX && x<=maxX && y>=minY && y<=maxY){ dragging=i; selected=i; offsetX=x-s.x; offsetY=y-s.y; return; }
+      if(x>=minX && x<=maxX && y>=minY && y<=maxY){
+        if(e.button===2){ resizing=i; startW=s.w; startH=s.h; return; }
+        dragging=i; selected=i; offsetX=x-s.x; offsetY=y-s.y; return; }
     }
   }
 });
 canvas.addEventListener('mousemove', e => {
-  if(dragging===null) return;
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
-  const s = shapes[dragging];
-  s.x = x - offsetX;
-  s.y = y - offsetY;
-  drawShapes();
+  if(dragging!==null){
+    const s = shapes[dragging];
+    s.x = x - offsetX;
+    s.y = y - offsetY;
+    drawShapes();
+    return;
+  }
+  if(resizing!==null){
+    const s=shapes[resizing];
+    s.w = Math.max(5, startW + (x - s.x));
+    s.h = Math.max(5, startH + (y - s.y));
+    drawShapes();
+  }
 });
-canvas.addEventListener('mouseup', ()=>{ dragging=null; });
+canvas.addEventListener('mouseup', ()=>{ dragging=null; resizing=null; });
+canvas.addEventListener('contextmenu',e=>e.preventDefault());
+canvas.addEventListener('wheel',e=>{
+  if(selected!==null && e.ctrlKey){
+    e.preventDefault();
+    const s=shapes[selected];
+    s.thickness=Math.max(1,(s.thickness||2)+(e.deltaY<0?1:-1));
+    drawShapes();
+  }
+});
 document.getElementById('add').addEventListener('click', ()=>{
   const type=document.getElementById('shape').value;
   const w=parseFloat(document.getElementById('width').value);
   const h=parseFloat(document.getElementById('height').value);
-  shapes.push({type,x:50,y:50,w,w,h});
+  const thickness=parseFloat(document.getElementById('thickness').value)||2;
+  shapes.push({type,x:50,y:50,w,w,h,thickness});
   drawShapes();
 });
 document.getElementById('delete').addEventListener('click', ()=>{
@@ -145,6 +177,38 @@ document.getElementById('smaller').addEventListener('click', ()=>{
     drawShapes();
   }
 });
+function calcLocalCG(){
+  let A=0,cx=0,cy=0;
+  shapes.forEach(s=>{
+    let area=0, sx=0, sy=0;
+    if(s.type==='rect'){ area=s.w*s.h; sx=s.x+s.w/2; sy=s.y+s.h/2; }
+    if(s.type==='tri'){ area=s.w*s.h/2; sx=s.x+s.w/3; sy=s.y+s.h/3; }
+    if(s.type==='circ'){ area=Math.PI*(s.w/2)**2; sx=s.x; sy=s.y; }
+    if(area>0){ A+=area; cx+=sx*area; cy+=sy*area; }
+  });
+  if(A>0){
+    document.getElementById('result').textContent=
+      `CG Local: (${(cx/A).toFixed(2)}, ${(cy/A).toFixed(2)})`;
+  }
+}
+function calcBackCG(){
+  fetch('http://localhost:5000/cg',{
+    method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({shapes})})
+  .then(r=>r.json())
+  .then(d=>{
+    if(d.cg_x!==undefined){
+      document.getElementById('result').textContent=
+        `CG Backend: (${d.cg_x.toFixed(2)}, ${d.cg_y.toFixed(2)})`;
+    }else if(d.error){
+      document.getElementById('result').textContent='Error: '+d.error;
+    }
+  }).catch(()=>{
+    document.getElementById('result').textContent='Error de conexión';
+  });
+}
+document.getElementById('cgLocal').addEventListener('click', calcLocalCG);
+document.getElementById('cgBack').addEventListener('click', calcBackCG);
 </script>
 </body>
 </html>

--- a/web_editor/server.py
+++ b/web_editor/server.py
@@ -1,0 +1,41 @@
+from flask import Flask, request, jsonify
+import numpy as np
+
+app = Flask(__name__)
+
+@app.route('/cg', methods=['POST'])
+def cg():
+    data = request.get_json(force=True)
+    shapes = data.get('shapes', [])
+    area_total = 0.0
+    cx_total = 0.0
+    cy_total = 0.0
+    for s in shapes:
+        t = s.get('type')
+        x = float(s.get('x', 0))
+        y = float(s.get('y', 0))
+        w = float(s.get('w', 0))
+        h = float(s.get('h', 0))
+        if t == 'rect':
+            area = w * h
+            cx = x + w/2
+            cy = y + h/2
+        elif t == 'tri':
+            area = w * h / 2
+            cx = x + w/3
+            cy = y + h/3
+        elif t == 'circ':
+            area = np.pi * (w/2)**2
+            cx = x
+            cy = y
+        else:
+            continue
+        area_total += area
+        cx_total += cx * area
+        cy_total += cy * area
+    if area_total == 0:
+        return jsonify({'error': 'area cero'}), 400
+    return jsonify({'cg_x': cx_total/area_total, 'cg_y': cy_total/area_total})
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- create simple `server.py` that exposes a `/cg` endpoint to compute the centre of gravity for shapes
- extend **figuras_irregulares.html** with local and backend CG calculation buttons
- allow resizing shapes with right mouse button and change line thickness with `Ctrl`+wheel
- add thickness input on new shapes and display results area
- update web editor README with instructions

## Testing
- `python3 -m py_compile web_editor/server.py`

------
https://chatgpt.com/codex/tasks/task_e_6850f9f5b5b4832fa74d7b04847da753