### PR TITLE
Add truss analysis module with formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,34 @@ El valor se mostrará en el registro y en los diagramas.
 4. Configura la viga y agrega las cargas necesarias.
 5. Usa **Par en Punto** para consultar el momento torsor si lo necesitas.
 6. Revisa los resultados en la pestaña de **Resultados**.
+
+### 11. Análisis de Armaduras y Bastidores
+
+Se añadió el módulo `estructuras_equilibrio.py` para resolver **armaduras planas**
+por el método de nodos utilizando únicamente las ecuaciones de equilibrio
+(`ΣFx = 0` y `ΣFy = 0`).
+Cada `Nodo` almacena sus coordenadas, las cargas externas y las restricciones en
+`x` y `y`. Las barras se definen indicando los nodos que conectan y el método
+`Armadura2D.resolver()` devuelve las fuerzas internas de cada barra junto con
+las reacciones en los apoyos.
+
+### 12. Formulario de Cálculos
+
+A continuación se listan las fórmulas utilizadas en cada apartado del programa:
+
+* **Reacciones de la viga**: se aplica el equilibrio estático
+  \(\sum F_y = 0\) y \(\sum M = 0\) para obtener `RA`, `RB` y `RC`.
+* **Cargas distribuidas**: la fuerza equivalente es
+  \(F = w \times (x_f - x_i)\) ubicada en el centroide del tramo.
+* **Centro de masa**: \(x_{cm} = \sum (x_i F_i) / \sum F_i\).
+* **Par torsor en un punto**: \(M(x) = T + \sum R_i (x - x_i) - \sum P_j
+  (x - x_j)\).
+* **Momento de inercia de la sección**: para cada rectángulo se usa
+  \(I = \tfrac{b h^3}{12}\) y el teorema de ejes paralelos para trasladar al
+  eje global.
+* **Armaduras**: en cada nodo se imponen
+  \(\sum F_x = 0\) y \(\sum F_y = 0\) para obtener las fuerzas internas de las
+  barras y las reacciones.
+
+Con estas expresiones es posible verificar manualmente cada resultado que
+entrega el simulador.

--- a/estructuras_equilibrio.py
+++ b/estructuras_equilibrio.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Analisis simplificado de armaduras y bastidores 2D usando ecuaciones de equilibrio."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+import numpy as np
+
+
+@dataclass
+class Nodo:
+    """Representa un nodo con coordenadas y cargas externas."""
+    x: float
+    y: float
+    carga_x: float = 0.0
+    carga_y: float = 0.0
+    restringido_x: bool = False
+    restringido_y: bool = False
+
+
+@dataclass
+class Barra:
+    """Barra que conecta dos nodos."""
+    n_i: int
+    n_j: int
+
+
+class Armadura2D:
+    """Resuelve armaduras planas por el metodo de nodos (joints)."""
+
+    def __init__(self, nodos: Dict[int, Nodo], barras: List[Barra]):
+        self.nodos = nodos
+        self.barras = barras
+
+    def resolver(self) -> Tuple[np.ndarray, Dict[int, Tuple[float, float]]]:
+        """Devuelve fuerzas en barras y reacciones (Rx, Ry) por nodo."""
+        num_barras = len(self.barras)
+        nodos = list(self.nodos.keys())
+        num_nodos = len(nodos)
+
+        # Mapear reacciones
+        reaccion_vars = []
+        for idx in nodos:
+            n = self.nodos[idx]
+            if n.restringido_x:
+                reaccion_vars.append((idx, 'Rx'))
+            if n.restringido_y:
+                reaccion_vars.append((idx, 'Ry'))
+        num_reacciones = len(reaccion_vars)
+
+        # Variables: fuerzas en barras + reacciones
+        num_vars = num_barras + num_reacciones
+        A = np.zeros((2 * num_nodos, num_vars))
+        b = np.zeros(2 * num_nodos)
+
+        # Fuerzas de barras
+        for k, barra in enumerate(self.barras):
+            i = barra.n_i
+            j = barra.n_j
+            ni = self.nodos[i]
+            nj = self.nodos[j]
+            L = np.hypot(nj.x - ni.x, nj.y - ni.y)
+            c = (nj.x - ni.x) / L
+            s = (nj.y - ni.y) / L
+            # Nodo i
+            row_ix = nodos.index(i) * 2
+            A[row_ix, k] = c
+            A[row_ix + 1, k] = s
+            # Nodo j
+            row_jx = nodos.index(j) * 2
+            A[row_jx, k] = -c
+            A[row_jx + 1, k] = -s
+
+        # Reacciones
+        for r_idx, (n_id, comp) in enumerate(reaccion_vars):
+            col = num_barras + r_idx
+            row = nodos.index(n_id) * 2
+            if comp == 'Rx':
+                A[row, col] = 1
+            else:
+                A[row + 1, col] = 1
+
+        # Vector b con cargas externas
+        for idx in nodos:
+            n = self.nodos[idx]
+            row = nodos.index(idx) * 2
+            b[row] = -n.carga_x
+            b[row + 1] = -n.carga_y
+
+        # Resolver sistema lineal
+        x = np.linalg.solve(A, b)
+
+        # Extraer resultados
+        fuerzas_barras = x[:num_barras]
+        reacciones = {}
+        for r_idx, (n_id, comp) in enumerate(reaccion_vars):
+            fuerza = x[num_barras + r_idx]
+            rx, ry = reacciones.get(n_id, (0.0, 0.0))
+            if comp == 'Rx':
+                rx = fuerza
+            else:
+                ry = fuerza
+            reacciones[n_id] = (rx, ry)
+
+        return fuerzas_barras, reacciones
+
+
+__all__ = ["Nodo", "Barra", "Armadura2D"]


### PR DESCRIPTION
## Summary
- add a new `estructuras_equilibrio.py` module for solving planar trusses with equilibrium
- document new module and include a formulas section in README

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py estructuras_equilibrio.py`

------
https://chatgpt.com/codex/tasks/task_e_6854956baca8832f8b585ae907fca65c