### PR TITLE
Fix dataclass field import

### DIFF
--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -12,7 +12,7 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolb
 from matplotlib.animation import FuncAnimation
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
 @dataclass


### PR DESCRIPTION
## Summary
- fix NameError by importing `field` from `dataclasses`

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`


------
https://chatgpt.com/codex/tasks/task_e_6855badf7fa4832fa9d082e1bfc80b78