### PR TITLE
Fix pyright import warning

### DIFF
--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -1,8 +1,9 @@
+# pyright: reportMissingImports=false
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 
 try:
-    import ttkbootstrap as ttkb
+    import ttkbootstrap as ttkb  # type: ignore
     BOOTSTRAP_AVAILABLE = True
 except ImportError:
     ttkb = None


### PR DESCRIPTION
## Summary
- avoid pyright `reportMissingImports` error for optional `ttkbootstrap`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6855bfe985b4832fbe055c3354b57891