### PR TITLE
Add section method and DCL plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ El programa usa **variables `tk.DoubleVar` y `tk.StringVar`** para guardar valor
 * **Centro de masa en 3D** y cálculo de fuerza a partir de un par torsor.
 * También calcula propiedades como el **área total**, **centro de gravedad de la sección transversal**, y **momento de inercia**.
 * **Nuevo**: análisis de **armaduras** mediante el método de nodos.
+* **Extra**: cálculo por el **método de secciones** y visualización de **diagramas de cuerpo libre** de cada nodo.
 
 ---
 


### PR DESCRIPTION
## Summary
- document truss section analysis and DCL in README
- add GUI controls for section method and node DCL
- implement drawing of DCL for nodes and for a cut section

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b246d37a48322bfdee82d3cd01469